### PR TITLE
Add array type to datatypes.

### DIFF
--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -7,6 +7,7 @@ var JSType = function(o){
 };
 
 module.exports = {
+  ARRAY: () => new JSType({ type: 'array' }),
   BIGINT: () => new JSType({ type: 'biginteger' }),
   BOOLEAN: () => new JSType({ type: 'boolean' }),
   BLOB: (tiny) => new JSType({type: 'blob', tiny: tiny ? true : false}),


### PR DESCRIPTION
It appears the `array` type was build out elsewhere in `joi-sequelize` but wasn't added to the data types. Adding this allows the use of the `Sequelize.ARRAY` type available when using Postgres.